### PR TITLE
Move data.table from Depends to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,8 +6,8 @@ Maintainer: Norm Matloff <normmatloff@gmail.com>
 Date: 2025-02-16
 Title: Top Frequency-Based Parallel Coordinates
 Description: Parallel coordinate plotting without the "black screen" problem 
-Depends: R (>= 3.2.0), data.table, plotly, freqparcoord, partools
-Imports:
+Depends: R (>= 3.2.0), plotly, freqparcoord, partools
+Imports: data.table
 Suggests: rmarkdown, knitr
 VignetteBuilder: knitr
 LazyLoad: no

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,4 @@
 import(freqparcoord)
-import(data.table)
 
 importFrom("grDevices", "as.raster", "colorRampPalette", "png")
 importFrom("graphics", "axis", "lines", "par", "plot",
@@ -9,6 +8,7 @@ importFrom("utils", "head")
 importFrom(data.table,as.data.table)
 importFrom(data.table,is.data.table)
 importFrom(data.table,".N")
+importFrom(data.table,data.table)
 importFrom("stats", "complete.cases")
 importFrom("utils", "data")
 importFrom("plotly", "plot_ly")


### PR DESCRIPTION
Closes #3. Copied over manually from a local Gemini-authored patch (so `R CMD check` was verified locally).